### PR TITLE
Use nosetest script in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
  # Another command/method to run tests
 script:
-  - py.test --cov-report term-missing --cov app
+  - nosetests --with-coverage --cover-package=app
 
 # Using codecov to get coverage
 after_success:


### PR DESCRIPTION
Use nosetests to run travis test builds instead of pytest